### PR TITLE
PR suggestions

### DIFF
--- a/crypto/awskms/awskms_test.go
+++ b/crypto/awskms/awskms_test.go
@@ -59,7 +59,7 @@ func TestManualKMSSigning(t *testing.T) {
 
 	// KMS_TEST_KEY_RESOURCE_ARN is an env var containing the resource ARN of a KMS key you
 	// have permissions to use.
-	os.Setenv("KMS_TEST_KEY_RESOURCE_ARN", "")
+	//os.Setenv("KMS_TEST_KEY_RESOURCE_ARN", "")
 	id := os.Getenv(`KMS_TEST_KEY_RESOURCE_ARN`)
 	t.Log(id)
 	key, err := awskms.KeyFromResourceARN(id)
@@ -68,13 +68,15 @@ func TestManualKMSSigning(t *testing.T) {
 	// initialize the client
 	ctx := context.Background()
 	// AWS SDK uses the default credential chain to find the credentials.
-	// You need to export env variables, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN
-	os.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	os.Setenv("AWS_SESSION_TOKEN", "")
+	// You either need to export env variables, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN
+	// or to install the aws kms CLI tool and set up your credentials (for instance in ~/.aws/credentials)
+	//os.Setenv("AWS_ACCESS_KEY_ID", "")
+	//os.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	//os.Setenv("AWS_SESSION_TOKEN", "")
 
 	defaultCfg, err := config.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
+	defaultCfg.Region = key.Region
 
 	cl := awskms.NewClient(defaultCfg)
 	require.NoError(t, err)

--- a/crypto/awskms/signer.go
+++ b/crypto/awskms/signer.go
@@ -25,7 +25,7 @@ import (
 	kms "github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/onflow/flow-go-sdk/crypto"
-	internal "github.com/onflow/flow-go-sdk/crypto/kms_internal"
+	"github.com/onflow/flow-go-sdk/crypto/internal"
 )
 
 var _ crypto.Signer = (*Signer)(nil)

--- a/crypto/cloudkms/cloudkms_test.go
+++ b/crypto/cloudkms/cloudkms_test.go
@@ -98,7 +98,7 @@ func TestManualKMSSigning(t *testing.T) {
 	// KMS_TEST_KEY_RESOURCE_ID is an env var containing the resource ID of a KMS key you
 	// have permissions to use.
 	id := os.Getenv(`KMS_TEST_KEY_RESOURCE_ID`)
-	fmt.Println(id)
+	t.Log(id)
 	key, err := cloudkms.KeyFromResourceID(id)
 	require.NoError(t, err)
 

--- a/crypto/cloudkms/signer.go
+++ b/crypto/cloudkms/signer.go
@@ -25,7 +25,7 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/onflow/flow-go-sdk/crypto"
-	internal "github.com/onflow/flow-go-sdk/crypto/kms_internal"
+	"github.com/onflow/flow-go-sdk/crypto/internal"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )

--- a/crypto/internal/util.go
+++ b/crypto/internal/util.go
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package kms_internal
+package internal
 
 import (
 	"encoding/asn1"
@@ -57,4 +57,3 @@ func curveOrder(curve crypto.SignatureAlgorithm) int {
 		panic("the curve is not supported")
 	}
 }
-


### PR DESCRIPTION
Here are some suggestions for https://github.com/onflow/flow-go-sdk/pull/340

- rename `kms_internal` to `internal` to not export functions beyond `/crypto`
- add aws region to the client configuration
- comment the `os.Setenv` as these are an example of setting env variables, but developers could use other methods.